### PR TITLE
Hoist CI build requirements to top of issue template

### DIFF
--- a/TRAVIS
+++ b/TRAVIS
@@ -2,12 +2,13 @@ Implement continuous integration
 
 Implement the "track test suite".  This suite should:
 
-- for each exercise in the track,
-  - run that exercise's test suite (aka the "exercise test suite");
-  - use the exercise's solution as the code under test.
-- ensure all test cases are enabled;
-- be executed on Travis CI;
-- be easy to run on a contributor/maintainer's local machine (i.e. a build script with any needed instructions).
+- for each exercise in the track
+  - run that exercise's test suite (aka the "exercise test suite")
+    - ensure all test cases are enabled
+  - use the exercise's example solution as the code under test
+- be executed on Travis CI
+- be easy to run on a contributor/maintainer's local machine (i.e. a build script)
+  - with instructions on how to do so in the track's `README.md`.
 
 **Definition of terms**
 
@@ -20,19 +21,24 @@ The goal of the "track test suite" is to ensure that the "exercise test suite"s 
 
 _Enabling all test cases_
 
-As described in [Contributing to Exercism: Writing exercise test suites](writing_tests.md), exercise test suites are written such that all but the first test case are skipped/pending/ignored.  For the purpose of the track test suite, all test cases should be enabled (simulating an Exercism user having completed the exercise).
+As described in [Contributing to Exercism: writing exercise test suites](writing_tests.md), exercise test suites in most language tracks are written such that all but the first test case are skipped/pending/ignored.  For the purpose of the track test suite, all test cases should be enabled (simulating an Exercism user having completed the exercise).
 
 Additionally, in some programming languages, the name of the file containing the solution is hard-coded in the test suite, and the example solution is not named in the way that we expect people to name their files.
 
 We will need to temporarily (and programmatically) edit the exercise test suites to ensure that all of their tests are active. We may also need to rename the example solution file(s) in order for the exercise test suite to run against it.
 
-It's important that if we rewrite files in any way during a test run, that these changes do not accidentally get checked in to the git repository.
+It's important that if we rewrite files in any way during a test run, that these changes do not accidentally get checked in to the Git repository.
 
-Therefore, many language tracks write the track test suite in such a way that it _copies_ the exercise to a temporary location outside of the git repository before editing or rewriting the exercise files during a test run.
+Therefore, many language tracks write the track test suite in such a way that it _copies_ the exercise to a temporary location outside of the Git repository before editing or rewriting the exercise files during a test run.
 
-_Configuring Travis CI_
+_Configuring hosted Continuous Integration_
 
-A contributor may forget to run the track test suite before submitting a PR.  Also, sometimes a test suite will succeed even when something is wrong with the test suite on a contributor's local machine because of some artifact of their local configuration.  Running the suite on a continuous integration server (here, Travis CI) ensures the track test suite is run from scratch.
+A contributor may forget to run the track test suite before submitting a PR.  Also, sometimes a test suite will succeed even when something is wrong with the test suite on a contributor's local machine because of some artifact of their local configuration.  Running the suite on a continuous integration server ensures the track test suite is run from scratch.
+
+Which hosted CI service to use depends on the base platform of this track.
+- [AppVeyor](https://www.appveyor.com/docs/) is recommended for Microsoft-based languages.
+- [Circle CI](https://circleci.com/docs/1.0/getting-started/) is what we tend to reach for for the Apple stack.
+- [Travis CI](https://docs.travis-ci.com/user/getting-started/TRAVIS) is typically used in most other cases.
 
 In order to successfully run the track test suite, Travis may need to be configured to provide a development environment for this track's language -or- a setup script needs to be provided to perform the setup.  [Travis Docs](https://docs.travis-ci.com) enumerate the supported languages and instructions for how to customize the build.
 

--- a/TRAVIS
+++ b/TRAVIS
@@ -1,6 +1,13 @@
 Implement continuous integration
 
-Implement a track test suite that can run both locally and on Travis CI. The track test suite should verify that each exercise makes sense, by running the exercise tests against the example solution.
+Implement the "track test suite".  This suite should:
+
+- for each exercise in the track,
+  - run that exercise's test suite (aka the "exercise test suite");
+  - use the exercise's solution as the code under test.
+- ensure all test cases are enabled;
+- be executed on Travis CI;
+- be easy to run on a contributor/maintainer's local machine (i.e. a build script with any needed instructions).
 
 **Definition of terms**
 
@@ -9,34 +16,31 @@ Implement a track test suite that can run both locally and on Travis CI. The tra
 
 **Background**
 
-When implementing an exercise test suite, we want to provide a good user experience for the people writing a solution to the exercise. People should not be confused or overwhelmed.
+The goal of the "track test suite" is to ensure that the "exercise test suite"s delivered to Exercism users will work properly.  The best way to do this is to execute the exercise test suite against a known good solution — the example solution in the exercise.
 
-In most Exercism language tracks, we simulate Test-Driven Development (TDD) by implementing the tests in order of increasing complexity. We try to ensure that each test either
+_Enabling all test cases_
 
-- helps triangulate a solution to be more generic, or
-- requires new functionality incrementally.
-
-Many test frameworks will randomize the order of the tests when running them. This is an excellent practice, which helps ensure that subsequent tests are not dependent on side effects from earlier tests. However, in order to simulate TDD we want tests to run *in the order that they are defined*, and we want them to *fail fast*, that is to say, as soon as the test suite encounters a failure, we want the execution to stop. This ensures that the person implementing the solution sees only one error or failure message at a time, unless they make a change which causes prior tests to fail.
-
-This is the same experience that they would get if they were implementing each new test themselves.
-
-Most testing frameworks do not have the necessary configuration options to get this behavior directly, but they often do have a way of marking tests as _skipped_ or _pending_. The mechanism for this will vary from language to language and from test framework to test framework.
-
-Whatever the mechanism—functions, methods, annotations, directives, commenting out tests, or some other approach—these are changes made directly to the test file. The person solving the exercise will need to edit the test file in order to "activate" each subsequent test.
-
-Any tests that are marked as skipped will not be verified by the track test suite unless special care is taken.
+As described in [Contributing to Exercism: Writing exercise test suites](writing_tests.md), exercise test suites are written such that all but the first test case are skipped/pending/ignored.  For the purpose of the track test suite, all test cases should be enabled (simulating an Exercism user having completed the exercise).
 
 Additionally, in some programming languages, the name of the file containing the solution is hard-coded in the test suite, and the example solution is not named in the way that we expect people to name their files.
 
 We will need to temporarily (and programmatically) edit the exercise test suites to ensure that all of their tests are active. We may also need to rename the example solution file(s) in order for the exercise test suite to run against it.
 
-**Avoiding accidental git check-ins**
-
 It's important that if we rewrite files in any way during a test run, that these changes do not accidentally get checked in to the git repository.
 
 Therefore, many language tracks write the track test suite in such a way that it _copies_ the exercise to a temporary location outside of the git repository before editing or rewriting the exercise files during a test run.
 
-**Working around long-running track test suites**
+_Configuring Travis CI_
+
+A contributor may forget to run the track test suite before submitting a PR.  Also, sometimes a test suite will succeed even when something is wrong with the test suite on a contributor's local machine because of some artifact of their local configuration.  Running the suite on a continuous integration server (here, Travis CI) ensures the track test suite is run from scratch.
+
+In order to successfully run the track test suite, Travis may need to be configured to provide a development environment for this track's language -or- a setup script needs to be provided to perform the setup.  [Travis Docs](https://docs.travis-ci.com) enumerate the supported languages and instructions for how to customize the build.
+
+_Running locally_
+
+Having to commit and push changes to GitHub (in order to trigger the CI build) and waiting for the results can be unnecessarily laborious for someone contributing to the track.  The same build process that runs on Travis CI should be executable locally.
+
+This is usually done by capturing whatever steps are required to run the track test suite in a single script or makefile.
 
 Usually as people are developing the track, they're focused on a single exercise. If running the entire track test suite against all of the exercises takes a long time, it is often worth making it possible to verify just one exercise at a time.
 

--- a/writing_tests.md
+++ b/writing_tests.md
@@ -1,0 +1,16 @@
+_(in fact, this would be part of the new "docs" repo, not a file in this repo.)_
+
+When implementing an exercise test suite, we want to provide a good user experience for the people writing a solution to the exercise. People should not be confused or overwhelmed.
+
+In most Exercism language tracks, we simulate Test-Driven Development (TDD) by implementing the tests in order of increasing complexity. We try to ensure that each test either
+
+- helps triangulate a solution to be more generic, or
+- requires new functionality incrementally.
+
+Many test frameworks will randomize the order of the tests when running them. This is an excellent practice, which helps ensure that subsequent tests are not dependent on side effects from earlier tests. However, in order to simulate TDD we want tests to run *in the order that they are defined*, and we want them to *fail fast*, that is to say, as soon as the test suite encounters a failure, we want the execution to stop. This ensures that the person implementing the solution sees only one error or failure message at a time, unless they make a change which causes prior tests to fail.
+
+This is the same experience that they would get if they were implementing each new test themselves.
+
+Most testing frameworks do not have the necessary configuration options to get this behavior directly, but they often do have a way of marking tests as _skipped_ or _pending_. The mechanism for this will vary from language to language and from test framework to test framework.
+
+Whatever the mechanism—functions, methods, annotations, directives, commenting out tests, or some other approach—these are changes made directly to the test file. The person solving the exercise will need to edit the test file in order to "activate" each subsequent test.


### PR DESCRIPTION
Feels like a lot of unilateral decisions in this PR; I hope I'm understanding the purpose and audience.

1. suggesting that we make explicit all the "requirements" of setting up CI at the very top of the file (the what).
2. elaborate the background on each "requirement" with similarly named sections (the why).
3. keep the excellent examples at the tail of the file (the how).

Also, there is background for writing high quality exercise test suites.  Suggesting we extract these to a separate file.  In fact, I believe this would go in the new docs repo in some section giving background on writing test suites.