### PR TITLE
Add a note about exercise ordering in the launch checklist

### DIFF
--- a/CHECKLIST
+++ b/CHECKLIST
@@ -24,6 +24,8 @@ The topics can be an empty list, and the difficulty level is from 1 to 10, and c
 ]
 ```
 
+Problems are delivered to users in the same order that they are listed in this "exercises" array. Try to order them by increasing difficulty, but don't worry too much—it can always be adjusted later.
+
 ## Step 2: Prepare the Track for Launch
 
 - [ ] Define `test_pattern` in `config.json`


### PR DESCRIPTION
@jonmcalder noted in https://github.com/exercism/xr/issues/5#issuecomment-290731415 that we haven't explained anything about exercise order. I've tried to add a small improvement here.

I've also opened an issue to start documenting our philosophy around tests, which would be handy to have! https://github.com/exercism/docs/issues/8