### PR TITLE
Add more context to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,43 @@
 # Request a new Exercism language track
 
-If there's a programming language that you would like Exercism to support, and which we don't
-yet have a repository for, open a [new issue][new-issue] in this repository.
+## How to request support for a new language track
+
+**Does Exercism already support the language?**
+
+Check [this list][trackler-tracks], which contains both the active and inactive tracks on the site.
+
+If you find the language, follow the links from that list to view the repository. The `config.json` file
+has an `active` key, which will be true or false.
+
+**Has someone else asked for it?**
+
+Do a search in this repository for the name of the language. Remember to check both open and closed issues.
 
 [new-issue]: https://github.com/exercism/request-new-language-track/issues/new
+[trackler-tracks]: https://github.com/exercism/trackler/tree/master/tracks
+
+## How to improve the process for the next new maintainer
+
+It's crucial that we improve the documentation and instructions for launching a track. The best people to discover
+issues with our current process is new maintainers, launching a track for the first time. Unfortunately,
+that's the worst possible time for them to fix the documentation, because they've got the least amount of
+knowledge about how Exercism is put together.
+
+The files in this repository serve as a template for a new track. Some files get edited and added to the track,
+others are used to [create new issues in the track][issue-templates], but are not added to the new repository.
+If new maintainers have questions, it will often be because these files are confusing or missing information.
+
+When that happens we should tweak the documentation for clarity in a new pull request to the request-new-language-track
+repository (not their repository) and tag the maintainer to review it. If it's still confusing, they'll know,
+and figuring out how to explain it will help us fix it.
+
+In some cases, we might discover that we're missing high-level documentation that should live in the [docs][]
+repo, in which case we should open an issue or pull request there, proposing the new documentation. Tag the new
+maintainer there, as well, to get their input on the new docs.
+
+[checklist]: https://github.com/exercism/request-new-language-track/blob/master/CHECKLIST
+[docs]: https://github.com/exercism/docs
+[issue-templates]: https://github.com/exercism/request-new-language-track/blob/master/bin/bootstrap#L67-L73
 
 ## How to bootstrap a new track
 


### PR DESCRIPTION
In the process of launching the R track, @jonmcalder had several questions that the documentation / launch checklist didn't understand. This suggests a process for improving the documentation reactively when new maintainers are working their way through the checklist for the first time.