### PR TITLE
Delete the ignored key from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,11 +10,6 @@
   "deprecated": [
 
   ],
-  "ignored": [
-    "bin",
-    "img",
-    "docs"
-  ],
   "foregone": [
 
   ]


### PR DESCRIPTION

We no longer support having exercise implementations in the root of the track, and therefore
we no longer need to ignore non-exercise directories.

Ref: https://github.com/exercism/meta/issues/3