### PR TITLE
Add maintainer file

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -94,6 +94,7 @@ Once the track is live and active, it will often get new contributions.
 - [ ] "Watch" the {{TRACK_ID}} repository
 - [ ] Find a second maintainer
 - [ ] Create a .github/PULL_REQUEST_TEMPLATE.md file, if necessary [see details](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/)
+- [ ] Have each maintainer submit a pull request to the `config/maintainers.json` file
 
 We've got a few years of experience maintaining language tracks on Exercism. Here's what we have learned:
 

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -1,0 +1,6 @@
+{
+  "maintainers": [
+
+  ],
+  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md"
+}


### PR DESCRIPTION
This adds a JSON stub that points to the documentation with a checklist item that ensures that new maintainers know about it, and can figure out how to fill it in.