### PR TITLE
Add questions about prism support in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,4 +15,10 @@
 
 **Is there a testing framework available for the language?**
 
+**Is this language listed as 'supported' by [Prism.js]([http://prismjs.com/#languages-list)?** If so
+- what is Prism's canonical spelling for the language?
+- what file extensions should be highlighted?
+
+**If it is not supported by Prism.js, what is the closest supported language it maps to?**
+
 **Who will be leading the effort to launch the track?**


### PR DESCRIPTION
We will be using Prism.js on v2.exercism.io for syntax highlighting.
We need to be able to map track IDs and their file extensions to the
name that Prism uses for the language.

Closes https://github.com/exercism/meta/issues/91