### PR TITLE
TRACK_README: link the image to the Travis page

### DIFF
--- a/TRACK_README.md
+++ b/TRACK_README.md
@@ -1,5 +1,5 @@
 # Exercism {{LANGUAGE}} Track
 
-![build status](https://travis-ci.org/exercism/{{TRACK_ID}}.svg?branch=master)
+[![build status](https://travis-ci.org/exercism/{{TRACK_ID}}.svg?branch=master)](https://travis-ci.org/exercism/{{TRACK_ID}})
 
 Exercism exercises in {{LANGUAGE}}.


### PR DESCRIPTION
Consider a recently created track such as https://github.com/exercism/shen

Note that in the README, the Travis CI image is a link to just the image.
It would be more convenient to link to the Travis CI page.
That makes it easier to see why a build passed or failed.