### PR TITLE
Fix track README build status link

### DIFF
--- a/TRACK_README.md
+++ b/TRACK_README.md
@@ -1,5 +1,5 @@
 # Exercism {{LANGUAGE}} Track
 
-![build status](https://travis-ci.org/exercism/{{TRACK_ID}}.svg?branch=master)
+[![Build Status](https://travis-ci.org/exercism/{{TRACK_ID}}.svg?branch=master)](https://travis-ci.org/exercism/{{TRACK_ID}})
 
 Exercism exercises in {{LANGUAGE}}.


### PR DESCRIPTION
The track README should link to the actual build on Travis rather than just to the svg of the build badge itself.

Closes #53 