### PR TITLE
Improve README template

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -2,12 +2,12 @@
 
 {{ .Spec.Description -}}
 {{- with .Hints }}
-{{ . }}
+{{ . -}}
 {{ end }}
 {{- with .TrackInsert }}
-{{ . }}
+{{ . -}}
 {{ end }}
-{{- with .Spec.Credits -}}
+{{- with .Spec.Credits }}
 ## Source
 
 {{ . }}


### PR DESCRIPTION
The improvement to the template ensure that the generated README have consistent single newline in the event of missing `.Hints`, `.TrackInsert`, and/or `.Spec.Credits`.