### PR TITLE
(chore) Ensure valid config.json after lint

### DIFF
--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -16,3 +16,6 @@ jobs:
 
       - name: Configlet Linter
         run: configlet lint
+
+      - name: Ensure valid JSON
+        run: jq '.' config.json


### PR DESCRIPTION
This catches trailing commas and things that may pass configlet but that `jq` knows are NOT valid JSON.