### PR TITLE
Add docs/config.json document

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -91,6 +91,7 @@ end
   "config.json",
   "README.md",
   "CHECKLIST.md",
+  File.join("docs", "config.json")
 ].each do |name|
   f = File.join(dir, name)
   contents = File.read(f)

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -8,6 +8,7 @@ rescue LoadError => e
 end
 require 'date'
 require 'fileutils'
+require 'securerandom'
 
 track_id = ENV['TRACK_ID']
 language = ENV['LANGUAGE']
@@ -85,6 +86,12 @@ f = File.join(dir, 'LICENSE')
 contents = File.read(f)
 File.open(f, "w") do |f|
   f.write contents.gsub(/\d{4}/, Date.today.year.to_s)
+end
+
+f = File.join(dir, 'docs', 'config.json')
+contents = File.read(f)
+File.open(f, "w") do |f|
+  f.write contents.gsub('{{UUID}}') {|m| SecureRandom.uuid }
 end
 
 [

--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "c4c4c0aa-673d-431c-ad61-f902275a70f4",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing {{LANGUAGE}} locally",
+      "blurb": "Learn how to install {{LANGUAGE}} locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "ae6b8e1c-538e-4431-89e9-c02640e4c3c5",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn {{LANGUAGE}}",
+      "blurb": "An overview of how to get started from scratch with {{LANGUAGE}}"
+    },
+    {
+      "uuid": "fa718304-b7c2-4114-a288-0b4b91414771",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the {{LANGUAGE}} track",
+      "blurb": "Learn how to test your {{LANGUAGE}} exercises on Exercism"
+    },
+    {
+      "uuid": "6e10c3d3-f463-4606-92fe-b3152d51de58",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful {{LANGUAGE}} resources",
+      "blurb": "A collection of useful resources to help you master {{LANGUAGE}}"
+    }
+  ]
+}

--- a/docs/config.json
+++ b/docs/config.json
@@ -1,28 +1,28 @@
 {
   "docs": [
     {
-      "uuid": "c4c4c0aa-673d-431c-ad61-f902275a70f4",
+      "uuid": "{{UUID}}",
       "slug": "installation",
       "path": "docs/INSTALLATION.md",
       "title": "Installing {{LANGUAGE}} locally",
       "blurb": "Learn how to install {{LANGUAGE}} locally to solve Exercism's exercises on your own machine"
     },
     {
-      "uuid": "ae6b8e1c-538e-4431-89e9-c02640e4c3c5",
+      "uuid": "{{UUID}}",
       "slug": "learning",
       "path": "docs/LEARNING.md",
       "title": "How to learn {{LANGUAGE}}",
       "blurb": "An overview of how to get started from scratch with {{LANGUAGE}}"
     },
     {
-      "uuid": "fa718304-b7c2-4114-a288-0b4b91414771",
+      "uuid": "{{UUID}}",
       "slug": "tests",
       "path": "docs/TESTS.md",
       "title": "Testing on the {{LANGUAGE}} track",
       "blurb": "Learn how to test your {{LANGUAGE}} exercises on Exercism"
     },
     {
-      "uuid": "6e10c3d3-f463-4606-92fe-b3152d51de58",
+      "uuid": "{{UUID}}",
       "slug": "resources",
       "path": "docs/RESOURCES.md",
       "title": "Useful {{LANGUAGE}} resources",


### PR DESCRIPTION
This PR adds support for the `docs/config.json` file, which is required to have the track documentation show up on 
https://exercism.org/docs/tracks 
