### PR TITLE
Link to new track documentation in checklist

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,7 @@
 Launch tracking
 
+Overall documentation for building an Exercism track lives at https://exercism.org/docs/building/tracks/new
+
 This issue helps keep track of the tasks you're working on towards launching this track.
 
 The next steps are:


### PR DESCRIPTION
The most up-to-date documentation is always going to be on the documentation on the Exercism site. Even though the checklist links out to individual items there, it seems useful to have a high level link.