### PR TITLE
Git ignore focused on Exercism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-*.swp
-.DS_Store
 bin/configlet
 bin/configlet.exe
 bin/latest-configlet.tar.gz


### PR DESCRIPTION
Avoids user choice of operating system, editor choices, etc, where those ignores should be set in the developers' excludes file locally.